### PR TITLE
infra: add mz stack

### DIFF
--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Variables
+IMAGE_TAG=latest
+IMAGE_NAME=localhost:5000/service-example-backend
+
+# Build and push
+docker build -f ./Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+docker push ${IMAGE_NAME}:${IMAGE_TAG}
+
+# Deploy
+kubectl apply -f ./deploy-dev.yml

--- a/deploy-dev.yml
+++ b/deploy-dev.yml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-example-backend
+spec:
+  selector:
+    app: service-example-backend
+  ports:
+    - port: 3000
+      targetPort: 3000
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: service-example-backend
+spec:
+  rules:
+    - host: service-example-backend.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: service-example-backend
+                port:
+                  number: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-example-backend
+spec:
+  selector:
+    matchLabels:
+      app: service-example-backend
+  template:
+    metadata:
+      labels:
+        app: service-example-backend
+    spec:
+      containers:
+        - name: service-example-backend
+          image: localhost:5000/service-example-backend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              cpu: 1
+              memory: 800Mi
+            requests:
+              cpu: 500m
+              memory: 300Mi
+          env:
+            - name: PORT
+              value: "3000"


### PR DESCRIPTION
This pull request introduces a new deployment script and configuration for the `service-example-backend`. The changes include adding a deployment shell script and a Kubernetes deployment configuration file.

Deployment script and configuration:

* [`deploy-dev.sh`](diffhunk://#diff-950d14ea3b670349124b480a440f9bb1d62656bd2ca2477b3d34aa1df1a3a679R1-R13): Added a new shell script to build, push, and deploy the Docker image for `service-example-backend` using Docker and Kubernetes.
* [`deploy-dev.yml`](diffhunk://#diff-2f4f015a9e223f216454f7ba44843ec4a772824aab4f7e37b229eae1d8f4ff33R1-R57): Added a new Kubernetes configuration file to define the service, ingress, and deployment for `service-example-backend`.